### PR TITLE
Fix 'cancel' button on CreateWorldScreen

### DIFF
--- a/src/main/java/com/redlimerl/tabfocus/mixins/CreateWorldScreenMixin.java
+++ b/src/main/java/com/redlimerl/tabfocus/mixins/CreateWorldScreenMixin.java
@@ -2,6 +2,7 @@ package com.redlimerl.tabfocus.mixins;
 
 import com.redlimerl.tabfocus.FocusableWidget;
 import net.minecraft.client.gui.screen.world.CreateWorldScreen;
+import net.minecraft.client.gui.screen.world.SelectWorldScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,6 +16,7 @@ public abstract class CreateWorldScreenMixin {
 
     @Redirect(method = "keyPressed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/world/CreateWorldScreen;buttonClicked(Lnet/minecraft/client/gui/widget/ButtonWidget;)V"))
     public void buttonClickedRedirect(CreateWorldScreen instance, ButtonWidget button) {
+        if (MinecraftClient.getInstance().currentScreen instanceof SelectWorldScreen) return;
         if (FocusableWidget.FOCUSED_WIDGET != null) {
             if (FocusableWidget.FOCUSED_WIDGET.isEquals(button) || FocusableWidget.FOCUSED_WIDGET.is(TextFieldWidget.class)) {
                 this.buttonClicked(button);


### PR DESCRIPTION
When pressing the 'cancel' button with tabfocus, a new world would create.
This is because the cancel button opened a new Screen, which sets FocusableWidget.FOCUSED_WIDGET to null.